### PR TITLE
fix(workflow): resolve branch collision and checkout conflict

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Create improvement PR if proposed
         if: hashFiles('.proposed-change.md') != ''
         run: |
-          BRANCH="analyze/$(date +%Y%m%d)"
+          BRANCH="analyze/$(date +%Y%m%d)-${GITHUB_RUN_NUMBER}"
           git checkout -b "$BRANCH"
           git add -A
           if [ -z "$(git status --porcelain)" ]; then

--- a/.github/workflows/reviewer.yml
+++ b/.github/workflows/reviewer.yml
@@ -230,6 +230,7 @@ jobs:
           fi
 
           echo "Structural files changed in merged PR — syncing README"
+          git checkout -- . || true
           git fetch origin main
           git checkout -B main origin/main
 


### PR DESCRIPTION
## Summary
- **#59**: `analyze.yml` — append `GITHUB_RUN_NUMBER` to branch name (`analyze/YYYYMMDD-N`) to prevent same-day push collisions
- **#53**: `reviewer.yml` — add `git checkout -- . || true` before README sync checkout to discard local state changes already committed via API

Fixes #59
Fixes #53

## Test plan
- [ ] Trigger analyze.yml twice on the same day — second run should create a distinct branch
- [ ] Merge a PR with structural file changes — reviewer README sync should not fail on dirty tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)