### PR TITLE
feat(harness): pipeline resilience — self-healing improvements

### DIFF
--- a/.github/workflows/claude-task.yml
+++ b/.github/workflows/claude-task.yml
@@ -56,7 +56,7 @@ jobs:
         if: inputs.open_pr == true
         id: branch
         run: |
-          BRANCH="task/manual-$(date -u +%Y%m%d-%H%M%S)"
+          BRANCH="task/manual-$(date -u +%Y%m%d)-${GITHUB_RUN_NUMBER}"
           git checkout -b "$BRANCH"
           echo "BRANCH=$BRANCH" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/discover.yml
+++ b/.github/workflows/discover.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Create PR with discovered projects
         if: steps.changes.outputs.has_changes == 'true'
         run: |
-          BRANCH="discover/$(date +%Y%m%d-%H%M%S)"
+          BRANCH="discover/$(date +%Y%m%d)-${GITHUB_RUN_NUMBER}"
           git checkout -b "$BRANCH"
           git add apps/
           git commit -m "feat: discover new projects in apps/"

--- a/.github/workflows/evolve.yml
+++ b/.github/workflows/evolve.yml
@@ -490,8 +490,6 @@ jobs:
           for f in $(git diff --name-only state/ 2>/dev/null; git ls-files --others --exclude-standard state/ 2>/dev/null); do
             ./scripts/commit-state.sh "$f" "state: evolve — $(date -u +%Y-%m-%dT%H:%M)"
           done
-          # Reset state/ changes so they don't get double-committed
-          git checkout -- state/ 2>/dev/null || true
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -534,6 +532,7 @@ jobs:
           gh label create "intent-driven" --color "5319e7" --description "Issue driven by human intent analysis" --force
           gh label create "agent-ready" --color "0e8a16" --description "Ready for coder agent" --force
           gh label create "needs-review" --color "fbca04" --description "Needs human review" --force
+          gh label create "likely-agent-fixable" --color "0e8a16" --description "Watcher determined this pipeline issue can be fixed by the coder agent" --force
           REPO_NAME=$(echo "$GITHUB_REPOSITORY" | cut -d/ -f2)
           gh label create "project:${REPO_NAME}" --color "c5def5" --description "${REPO_NAME} project" --force
         env:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -141,6 +141,16 @@ jobs:
             changing GitHub App permissions, configuring external services, repository settings changes)
             vs. a code fix the agent can make (editing workflow YAML, fixing scripts, updating configs).
 
+            Strong signals that this IS agent-fixable (bias toward agent-ready):
+            - Issue body contains a "Proposed Fix" or "Suggested Fix" section
+            - Issue references specific file paths in .github/workflows/ or scripts/
+            - Issue contains concrete code snippets or one-line changes
+            - Issue was created by watcher.yml (title starts with [pipeline])
+            - Issue has a label "likely-agent-fixable"
+
+            If ANY of these signals are present AND the fix does NOT require secrets/permissions/
+            external service config, classify as agent-fixable.
+
             If the agent CAN fix it (code/config changes):
               gh issue edit ${NUM} --add-label "agent-ready" --repo ${{ github.repository }}
               gh issue comment ${NUM} --body "**Triage:** Pipeline failure identified and elaborated. The coder agent will investigate and fix shortly." --repo ${{ github.repository }}

--- a/.github/workflows/watcher.yml
+++ b/.github/workflows/watcher.yml
@@ -104,6 +104,9 @@ jobs:
           - Get the failure logs: gh run view <id> --log-failed 2>&1 | tail -20
           - Create a [pipeline] issue if one doesn't exist for this failure pattern
           - Include the error message and suggested fix in the issue body
+          - If the failure is in workflow YAML, scripts, or config (NOT secrets/permissions/
+            external services), also add the label "likely-agent-fixable" to the issue.
+            This tells the triage agent to classify it as agent-ready without hesitation.
 
           ### 3. Detect stuck runs
           - Runs in_progress for >30 minutes may be stuck

--- a/scripts/commit-state.sh
+++ b/scripts/commit-state.sh
@@ -39,6 +39,7 @@ for i in $(seq 1 $MAX_RETRIES); do
   # Check success
   if echo "$RESULT" | grep -q '"content"'; then
     echo "Updated $FILE_PATH"
+    git checkout -- "$FILE_PATH" 2>/dev/null || true
     exit 0
   fi
 


### PR DESCRIPTION
## Summary
Four improvements that close the gap where the pipeline detects failures but can't self-fix them:

- **commit-state.sh self-cleanup** — resets local files after API commit, preventing dirty-tree conflicts in downstream git operations (root cause of #53, systemic fix)
- **Smarter triage for pipeline-fix** — explicit heuristic signals (proposed fix section, file paths, code snippets, `likely-agent-fixable` label) that bias toward `agent-ready` instead of classification limbo
- **Unique branch names** — `GITHUB_RUN_NUMBER` replaces `%H%M%S` timestamps in discover.yml and claude-task.yml (matches analyze.yml fix from #60)
- **Watcher fixability signal** — watcher adds `likely-agent-fixable` label to code/config pipeline issues, giving triage a clear signal

## Why this matters
Issues #59 and #53 were both detected by watcher (issues created correctly) but never reached the coder because triage couldn't confidently classify them as agent-fixable. These changes close that handoff gap and prevent the underlying bug classes from recurring.

## Files changed (6)
| File | Change |
|------|--------|
| `scripts/commit-state.sh` | +1 line: `git checkout` after API success |
| `.github/workflows/evolve.yml` | -2 lines redundant cleanup, +1 line label creation |
| `.github/workflows/triage.yml` | +10 lines: agent-fixable signal heuristic |
| `.github/workflows/watcher.yml` | +3 lines: `likely-agent-fixable` label guidance |
| `.github/workflows/discover.yml` | 1 line: branch naming |
| `.github/workflows/claude-task.yml` | 1 line: branch naming |

## Test plan
- [ ] Verify `commit-state.sh` resets local files after API commit (next workflow run that writes state)
- [ ] Trigger watcher on a pipeline failure — confirm `likely-agent-fixable` label is added
- [ ] Verify triage classifies a `[pipeline]` issue with proposed fix as `agent-ready`
- [ ] Trigger discover.yml or claude-task.yml twice — confirm unique branch names

🤖 Generated with [Claude Code](https://claude.com/claude-code)