### PR TITLE
refactor(harness): 1.2b-i mechanical carry-overs

### DIFF
--- a/harness/lib/ledger.py
+++ b/harness/lib/ledger.py
@@ -8,9 +8,37 @@ from __future__ import annotations
 import json
 from functools import lru_cache
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TypedDict
 
 import jsonschema
+
+
+class GeneratorBlock(TypedDict):
+    prompt_version: str
+    output_summary: str
+    diff_lines: int
+    tokens: int
+
+
+class EvaluatorBlock(TypedDict):
+    prompt_version: str
+    verdict: str
+    reason: str
+    tokens: int
+
+
+class LedgerEntry(TypedDict):
+    run_id: str
+    ts: str
+    skill: str
+    status: str
+    pr: Optional[int]
+    generator: Optional[GeneratorBlock]
+    evaluator: Optional[EvaluatorBlock]
+    duration_s: int
+    total_tokens: int
+    verdict: Optional[str]
+    verdict_note: Optional[str]
 
 
 _SCHEMA_PATH = Path(__file__).parent / "ledger.schema.json"
@@ -118,7 +146,7 @@ def last_run_id(ledger_path: Path) -> Optional[int]:
     return int(last["run_id"].split("-")[1])
 
 
-def append(ledger_path: Path, entry: dict) -> None:
+def append(ledger_path: Path, entry: LedgerEntry) -> None:
     """Validate then append entry as a compact JSON line.
 
     Creates parent directories and the file if missing. On validation

--- a/harness/lib/pr_opener.py
+++ b/harness/lib/pr_opener.py
@@ -13,7 +13,7 @@ from typing import Optional, Protocol
 class PROpener(Protocol):
     """Opens a PR and returns its number."""
 
-    def open(self, *, title: str, body: str, branch: str, diff: str) -> int: ...
+    def open(self, *, title: str, body: str, branch: str) -> int: ...
 
 
 class FakePROpener:
@@ -32,7 +32,7 @@ class FakePROpener:
         self._sink_dir = sink_dir
         self.calls: list[dict] = []
 
-    def open(self, *, title: str, body: str, branch: str, diff: str) -> int:
+    def open(self, *, title: str, body: str, branch: str) -> int:
         n = self._next
         self._next += 1
         record = {
@@ -40,7 +40,6 @@ class FakePROpener:
             "title": title,
             "body": body,
             "branch": branch,
-            "diff": diff,
         }
         self.calls.append(record)
         if self._sink_dir is not None:

--- a/harness/lib/runner.py
+++ b/harness/lib/runner.py
@@ -99,19 +99,19 @@ def run_skill(
     elif result.proposed_diff_path is None:
         status = "no_change"
         generator = {
-            "prompt_version": "stub-v1",
+            "prompt_version": result.prompt_version,
             "output_summary": result.summary,
             "diff_lines": 0,
-            "tokens": 0,
+            "tokens": result.tokens,
         }
         pr = None
     else:
         diff_lines = _count_diff_lines(diff_text)
         generator = {
-            "prompt_version": "stub-v1",
+            "prompt_version": result.prompt_version,
             "output_summary": result.summary,
             "diff_lines": diff_lines,
-            "tokens": 0,
+            "tokens": result.tokens,
         }
         try:
             pr = pr_opener.open(

--- a/harness/lib/runner.py
+++ b/harness/lib/runner.py
@@ -77,8 +77,8 @@ def run_skill(
         result = executor.execute(skill_dir, repo_dir, scratch)
 
         # 2f. Persist subprocess output.
-        (artifact_dir / "stub.stdout").write_text(result.stdout)
-        (artifact_dir / "stub.stderr").write_text(result.stderr)
+        (artifact_dir / "executor.stdout").write_text(result.stdout)
+        (artifact_dir / "executor.stderr").write_text(result.stderr)
         if result.proposed_diff_path is not None:
             shutil.copyfile(result.proposed_diff_path, artifact_dir / "proposed.diff")
         if result.proposed_md_path is not None:
@@ -126,7 +126,7 @@ def run_skill(
             status = "error"
             generator = None
             pr = None
-            (artifact_dir / "stub.stderr").write_text(
+            (artifact_dir / "executor.stderr").write_text(
                 result.stderr + f"\n[runner] pr_opener failed: {exc}\n{tb}"
             )
 

--- a/harness/lib/runner.py
+++ b/harness/lib/runner.py
@@ -16,6 +16,7 @@ from time import monotonic
 from typing import Any, Callable, Optional
 
 from harness.lib import ledger
+from harness.lib.ledger import LedgerEntry
 from harness.lib.pr_opener import PROpener
 from harness.lib.skill_executor import SkillExecutor
 
@@ -53,7 +54,7 @@ def run_skill(
     pr_opener: PROpener,
     skill_name: Optional[str] = None,
     now: Optional[Callable[[], datetime]] = None,
-) -> dict:
+) -> LedgerEntry:
     """Run one skill against a repo. Returns the ledger entry appended.
 
     See the data-flow section of the Phase 1.2a design doc for the
@@ -118,7 +119,6 @@ def run_skill(
                 title=f"[tokenman] {skill}: {result.summary}",
                 body=result.summary,
                 branch=f"tokenman/{skill}/{run_id}",
-                diff=diff_text,
             )
             status = "pr_opened"
         except Exception as exc:

--- a/harness/lib/skill_executor.py
+++ b/harness/lib/skill_executor.py
@@ -43,8 +43,13 @@ class StubSkillExecutor:
     and stderr are captured in full. Not used outside of tests.
     """
 
-    def __init__(self, extra_env: Optional[dict[str, str]] = None) -> None:
+    def __init__(
+        self,
+        extra_env: Optional[dict[str, str]] = None,
+        timeout_s: int = 30,
+    ) -> None:
         self._extra_env = dict(extra_env) if extra_env else {}
+        self._timeout_s = timeout_s
 
     def execute(
         self,
@@ -54,24 +59,34 @@ class StubSkillExecutor:
     ) -> ExecutionResult:
         entrypoint = skill_dir / "stub.sh"
         env = {**os.environ, **self._extra_env}
-        proc = subprocess.run(
-            ["bash", str(entrypoint), str(scratch_dir)],
-            cwd=str(repo_dir),
-            env=env,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        try:
+            proc = subprocess.run(
+                ["bash", str(entrypoint), str(scratch_dir)],
+                cwd=str(repo_dir),
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=self._timeout_s,
+            )
+            stdout = proc.stdout
+            stderr = proc.stderr
+            exit_code = proc.returncode
+        except subprocess.TimeoutExpired as e:
+            stdout = e.stdout or ""
+            stderr = (e.stderr or "") + f"\n[executor] stub.sh timed out after {self._timeout_s}s\n"
+            exit_code = -1
+
         diff = scratch_dir / "proposed.diff"
         md = scratch_dir / "proposed.md"
         first_stdout_line = next(
-            (ln for ln in proc.stdout.splitlines() if ln.strip()),
-            f"{skill_dir.name}: exit {proc.returncode}",
+            (ln for ln in stdout.splitlines() if ln.strip()),
+            f"{skill_dir.name}: exit {exit_code}",
         )
         return ExecutionResult(
-            exit_code=proc.returncode,
-            stdout=proc.stdout,
-            stderr=proc.stderr,
+            exit_code=exit_code,
+            stdout=stdout,
+            stderr=stderr,
             proposed_diff_path=diff if diff.is_file() else None,
             proposed_md_path=md if md.is_file() else None,
             summary=first_stdout_line,

--- a/harness/lib/skill_executor.py
+++ b/harness/lib/skill_executor.py
@@ -20,6 +20,8 @@ class ExecutionResult:
     proposed_diff_path: Optional[Path]
     proposed_md_path: Optional[Path]
     summary: str
+    prompt_version: str = "unknown"
+    tokens: int = 0
 
 
 class SkillExecutor(Protocol):
@@ -73,4 +75,6 @@ class StubSkillExecutor:
             proposed_diff_path=diff if diff.is_file() else None,
             proposed_md_path=md if md.is_file() else None,
             summary=first_stdout_line,
+            prompt_version="stub-v1",
+            tokens=0,
         )

--- a/tests/test_pr_opener.py
+++ b/tests/test_pr_opener.py
@@ -9,34 +9,33 @@ from harness.lib.pr_opener import FakePROpener
 
 def test_fake_pr_opener_returns_incrementing_integers() -> None:
     op = FakePROpener()
-    n1 = op.open(title="t1", body="b1", branch="br1", diff="d1")
-    n2 = op.open(title="t2", body="b2", branch="br2", diff="d2")
-    n3 = op.open(title="t3", body="b3", branch="br3", diff="d3")
+    n1 = op.open(title="t1", body="b1", branch="br1")
+    n2 = op.open(title="t2", body="b2", branch="br2")
+    n3 = op.open(title="t3", body="b3", branch="br3")
     assert n2 == n1 + 1
     assert n3 == n2 + 1
 
 
 def test_fake_pr_opener_custom_start() -> None:
     op = FakePROpener(start=500)
-    n1 = op.open(title="t", body="b", branch="br", diff="d")
+    n1 = op.open(title="t", body="b", branch="br")
     assert n1 == 500
 
 
 def test_fake_pr_opener_records_calls() -> None:
     op = FakePROpener()
-    op.open(title="hello", body="world", branch="tokenman/x/r-0001", diff="--- a\n+++ b\n")
+    op.open(title="hello", body="world", branch="tokenman/x/r-0001")
     assert len(op.calls) == 1
     call = op.calls[0]
     assert call["title"] == "hello"
     assert call["body"] == "world"
     assert call["branch"] == "tokenman/x/r-0001"
-    assert call["diff"] == "--- a\n+++ b\n"
 
 
 def test_fake_pr_opener_writes_sink_files(tmp_path: Path) -> None:
     sink = tmp_path / "prs"
     op = FakePROpener(sink_dir=sink, start=2000)
-    n = op.open(title="t", body="b", branch="br", diff="d")
+    n = op.open(title="t", body="b", branch="br")
     assert n == 2000
     written = sink / "pr-2000.json"
     assert written.is_file()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -118,8 +118,8 @@ def test_run_skill_propose_diff_opens_pr(tmp_path: Path) -> None:
     art = runs_dir / "r-0001"
     assert (art / "proposed.diff").is_file()
     assert (art / "proposed.md").is_file()
-    assert (art / "stub.stdout").is_file()
-    assert (art / "stub.stderr").is_file()
+    assert (art / "executor.stdout").is_file()
+    assert (art / "executor.stderr").is_file()
     assert (art / "ledger.entry").is_file()
     assert json.loads((art / "ledger.entry").read_text()) == entry
 
@@ -157,8 +157,8 @@ def test_run_skill_no_change_skips_pr_opener(tmp_path: Path) -> None:
     art = runs_dir / "r-0001"
     assert not (art / "proposed.diff").exists()
     assert not (art / "proposed.md").exists()
-    assert (art / "stub.stdout").is_file()
-    assert (art / "stub.stderr").is_file()
+    assert (art / "executor.stdout").is_file()
+    assert (art / "executor.stderr").is_file()
     assert (art / "ledger.entry").is_file()
 
 
@@ -185,8 +185,8 @@ def test_run_skill_crash_records_error(tmp_path: Path) -> None:
     assert pr_opener.calls == []
 
     art = runs_dir / "r-0001"
-    assert (art / "stub.stdout").is_file()
-    stderr_content = (art / "stub.stderr").read_text()
+    assert (art / "executor.stdout").is_file()
+    stderr_content = (art / "executor.stderr").read_text()
     assert "crashing on purpose" in stderr_content
     assert (art / "ledger.entry").is_file()
 
@@ -302,8 +302,8 @@ def test_run_skill_leaves_no_ledger_entry_on_append_failure(tmp_path: Path) -> N
 
     # Artifacts present (subprocess did run), but per-run ledger.entry absent.
     art = runs_dir / "r-0002"
-    assert (art / "stub.stdout").is_file()
-    assert (art / "stub.stderr").is_file()
+    assert (art / "executor.stdout").is_file()
+    assert (art / "executor.stderr").is_file()
     assert not (art / "ledger.entry").exists()
 
 
@@ -346,6 +346,6 @@ def test_run_skill_records_error_when_pr_opener_raises(tmp_path: Path) -> None:
     # opener ran), stderr captures the failure message and traceback.
     art = runs_dir / "r-0001"
     assert (art / "proposed.diff").is_file()
-    stderr_content = (art / "stub.stderr").read_text()
+    stderr_content = (art / "executor.stderr").read_text()
     assert "pr_opener failed: boom" in stderr_content
     assert "RuntimeError" in stderr_content

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -105,6 +105,7 @@ def test_run_skill_propose_diff_opens_pr(tmp_path: Path) -> None:
     # stub fixture diff has 2 content +/- lines (2x '+'), headers excluded.
     assert entry["generator"]["diff_lines"] == 2
     assert entry["generator"]["prompt_version"] == "stub-v1"
+    assert entry["generator"]["tokens"] == 0
     assert entry["evaluator"] is None
     assert entry["total_tokens"] == 0
 
@@ -148,6 +149,7 @@ def test_run_skill_no_change_skips_pr_opener(tmp_path: Path) -> None:
     assert entry["status"] == "no_change"
     assert entry["pr"] is None
     assert entry["generator"]["diff_lines"] == 0
+    assert entry["generator"]["prompt_version"] == "stub-v1"
     assert entry["generator"]["tokens"] == 0
     assert entry["total_tokens"] == 0
     assert pr_opener.calls == []

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -127,7 +127,8 @@ def test_run_skill_propose_diff_opens_pr(tmp_path: Path) -> None:
     assert len(pr_opener.calls) == 1
     call = pr_opener.calls[0]
     assert call["branch"] == "tokenman/stub-readme/r-0001"
-    assert "Stub-readme added this line" in call["diff"]
+    diff_on_disk = (runs_dir / "r-0001" / "proposed.diff").read_text()
+    assert "Stub-readme added this line" in diff_on_disk
 
 
 def test_run_skill_no_change_skips_pr_opener(tmp_path: Path) -> None:
@@ -315,7 +316,7 @@ def test_run_skill_records_error_when_pr_opener_raises(tmp_path: Path) -> None:
     repo_dir, ledger_path, runs_dir = _prepare_repo_copy(tmp_path)
 
     class BrokenPROpener:
-        def open(self, *, title, body, branch, diff):
+        def open(self, *, title, body, branch):
             raise RuntimeError("boom")
 
     executor = StubSkillExecutor(extra_env={"STUB_MODE": "propose_diff"})

--- a/tests/test_skill_executor.py
+++ b/tests/test_skill_executor.py
@@ -21,6 +21,8 @@ def test_stub_no_change_mode(tmp_path: Path) -> None:
     assert result.proposed_md_path is None
     assert "no changes needed" in result.stdout
     assert result.summary.startswith("stub-readme: no changes")
+    assert result.prompt_version == "stub-v1"
+    assert result.tokens == 0
 
 
 def test_stub_propose_diff_mode(tmp_path: Path) -> None:
@@ -33,6 +35,8 @@ def test_stub_propose_diff_mode(tmp_path: Path) -> None:
     assert result.proposed_md_path.is_file()
     assert "proposed 1 diff" in result.stdout
     assert "Stub-readme added this line" in result.proposed_diff_path.read_text()
+    assert result.prompt_version == "stub-v1"
+    assert result.tokens == 0
 
 
 def test_stub_crash_mode(tmp_path: Path) -> None:
@@ -41,6 +45,8 @@ def test_stub_crash_mode(tmp_path: Path) -> None:
     assert result.exit_code == 2
     assert "crashing on purpose" in result.stderr
     assert result.proposed_diff_path is None
+    assert result.prompt_version == "stub-v1"
+    assert result.tokens == 0
 
 
 def test_stub_default_mode_is_no_change(tmp_path: Path) -> None:

--- a/tests/test_skill_executor.py
+++ b/tests/test_skill_executor.py
@@ -1,6 +1,7 @@
 """Integration tests for harness.lib.skill_executor.StubSkillExecutor."""
 from __future__ import annotations
 
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -54,4 +55,26 @@ def test_stub_default_mode_is_no_change(tmp_path: Path) -> None:
     executor = StubSkillExecutor()
     result = executor.execute(STUB_SKILL_DIR, FIXTURE_REPO, tmp_path)
     assert result.exit_code == 0
+    assert result.proposed_diff_path is None
+
+
+def test_stub_timeout_surfaces_as_error(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "slow-skill"
+    skill_dir.mkdir()
+    (skill_dir / "stub.sh").write_text(textwrap.dedent("""\
+        #!/usr/bin/env bash
+        sleep 3
+        echo "should never print"
+    """))
+    (skill_dir / "stub.sh").chmod(0o755)
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    scratch_dir = tmp_path / "scratch"
+    scratch_dir.mkdir()
+
+    executor = StubSkillExecutor(timeout_s=1)
+    result = executor.execute(skill_dir, repo_dir, scratch_dir)
+
+    assert result.exit_code == -1
+    assert "timed out" in result.stderr
     assert result.proposed_diff_path is None


### PR DESCRIPTION
## Summary

Four mechanical refactors from the 1.2a reviewer's list — unblocks 1.2b-ii without mixing the refactor with the real integration work. No behavior changes.

- \`ExecutionResult\` gains \`prompt_version\` + \`tokens\`; runner reads them instead of hardcoding (\`7e135db\`)
- Artifact files renamed \`stub.{stdout,stderr}\` → \`executor.{stdout,stderr}\` (\`112b2ec\`)
- \`StubSkillExecutor(timeout_s=...)\` surfaces timeouts as \`exit_code=-1\` (\`6dffc3f\`)
- \`PROpener.open\` drops the \`diff\` arg; \`LedgerEntry\` TypedDict added (\`4a86d83\`)

Parent spec: \`docs/superpowers/specs/2026-04-18-phase-1-2b-real-skill-integration-design.md\` (§ 1.2b-i refactor).

## Test plan

- [x] \`pytest -q\` green: 51 passed (baseline 50 + 1 new timeout test)
- [x] No leftover \`stub.stdout\`/\`stub.stderr\` references anywhere under \`harness/\` or \`tests/\`
- [x] Imports work: \`from harness.lib.ledger import LedgerEntry, GeneratorBlock, EvaluatorBlock\`
- [ ] Reviewer spot-check: commit-by-commit each surfaces exactly one concern

🤖 Generated with [Claude Code](https://claude.com/claude-code)