### PR TITLE
feat(harness): 1.2b-ii real skill integration

### DIFF
--- a/.tokenman/CLAUDE.md
+++ b/.tokenman/CLAUDE.md
@@ -13,6 +13,7 @@
 - harness/                     # the runtime itself
 - scoping/                     # the scoping logic itself
 - onboarding/                  # the onboarding logic itself
+- skills/                      # temporary bootstrap (Phase 1.2b) — see skills/README.md
 - recommended-skills.yaml      # the catalog
 - pricing.yaml                 # budget calibration
 - .github/                     # the workflows

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,21 @@ user runs `/tokenman init` in their repo:
 - `harness/` — runtime code and workflow templates
 - `scoping/` — discovery and scope-proposal logic
 - `onboarding/` — guided first-run flow
+- `skills/` — **temporary** bootstrap for Phase 1.2b; see below
 - `recommended-skills.yaml` — curated catalog
 - `pricing.yaml` — budget calibration data
 - `docs/` — documentation
 - `tests/fixtures/` — synthetic consumer repos for harness testing
+
+### `skills/` — temporary bootstrap
+
+`skills/readme-maintainer/` lives in-tree during Phase 1.2b so the
+harness has a real skill to invoke before the external skills
+ecosystem exists. This is a deliberate, scoped violation of spec §5.1
+("tokenman ships zero skills"). It must be split out to a standalone
+repo before Phase 3 opens dogfood runs against the library itself.
+Do not add more skills here. See `skills/README.md` for the full
+rationale and exit plan.
 
 Edits to source-zone files are the main library-development work.
 Everything in `tests/fixtures/` stays pristine — harness tests reset it.
@@ -76,9 +87,12 @@ The Python harness lives under `harness/lib/`:
 
 - `harness/lib/ledger.schema.json` — canonical ledger shape (from Phase 1.1).
 - `harness/lib/ledger.py` — `validate()`, `append()`, `last_run_id()`. Enforces the conditional invariants the JSON Schema cannot express.
-- `harness/lib/skill_executor.py` — `ExecutionResult`, `SkillExecutor` Protocol, `StubSkillExecutor` (tests only). Phase 1.2b adds `ClaudeSkillExecutor`.
-- `harness/lib/pr_opener.py` — `PROpener` Protocol, `FakePROpener` (tests only). Phase 1.2b adds `GhPROpener`.
+- `harness/lib/skill_executor.py` — `ExecutionResult`, `SkillExecutor` Protocol, `StubSkillExecutor` (tests only), `ClaudeSkillExecutor` (Phase 1.2b-ii, `claude -p` backed).
+- `harness/lib/pr_opener.py` — `PROpener` Protocol + `PROpenerError`, `FakePROpener` (tests only), `GhPROpener` (Phase 1.2b-ii, `gh pr create` backed).
+- `harness/lib/git_ops.py` — `apply_diff_and_push` (branch/apply/commit/push, Phase 1.2b-ii).
 - `harness/lib/runner.py` — `run_skill`, the orchestrator.
+- `harness/run/__main__.py` — `python -m harness.run` CLI (Phase 1.2b-ii).
+- `harness/prompts/unattended_framing.v1.md` — versioned system-prompt framing for the unattended-claude invocation (Phase 1.2b-ii).
 
 Tests for each module live at `tests/test_<module>.py`. The stub skill used by executor + runner integration tests lives at `tests/fixtures/skills/stub-readme/`.
 
@@ -86,7 +100,8 @@ Run `pytest` from the repo root after `pip install -e '.[dev]'`.
 
 ## Status
 
-Phase 0 scaffolding is in place. Phase 1.1 has locked the ledger
-schema and reworked `status.sh`. The harness runner is not
-implemented yet — Phase 1.2 covers that. See `docs/spec.md` §12 for
-the full phased roadmap.
+Phase 1.2b-ii is the current milestone: real-skill integration. The
+runner now calls `claude -p` via `ClaudeSkillExecutor`, opens PRs via
+`GhPROpener`, and exposes a `python -m harness.run` CLI consumed by a
+consumer-deployable workflow template. `.tokenman/PAUSE` remains on
+through Phase 2. See `docs/spec.md` §12 for the full phased roadmap.

--- a/harness/lib/git_ops.py
+++ b/harness/lib/git_ops.py
@@ -1,0 +1,89 @@
+"""Git operations for the tokenman runner.
+
+Factored out of runner.py so the branch/apply/commit/push flow has a
+single, unit-testable home. Executed after the executor produces a
+proposed.diff and before pr_opener.open runs.
+"""
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class GitOpsError(RuntimeError):
+    """Raised when any git step fails. Wraps the captured stderr."""
+
+
+@dataclass(frozen=True)
+class GitIdentity:
+    name: str
+    email: str
+
+
+def _run(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        input=input_text,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def apply_diff_and_push(
+    *,
+    repo_dir: Path,
+    diff_text: str,
+    branch: str,
+    base: str,
+    message: str,
+    identity: GitIdentity,
+    remote: str = "origin",
+) -> None:
+    """Create `branch` off `base`, apply `diff_text`, commit with
+    `identity`, and push to `remote`.
+
+    Rolls back the local branch on failure (deletes it if it was
+    created by this call). Raises GitOpsError on any failed step.
+    """
+    created_branch = False
+
+    sw = _run(["git", "switch", "-c", branch, base], cwd=repo_dir)
+    if sw.returncode != 0:
+        raise GitOpsError(f"git switch -c {branch} {base} failed: {sw.stderr.strip()}")
+    created_branch = True
+
+    try:
+        ap = _run(["git", "apply", "--index", "-"], cwd=repo_dir, input_text=diff_text)
+        if ap.returncode != 0:
+            raise GitOpsError(f"git apply failed: {ap.stderr.strip()}")
+
+        co = _run(
+            [
+                "git",
+                "-c", f"user.name={identity.name}",
+                "-c", f"user.email={identity.email}",
+                "commit",
+                "-m", message,
+            ],
+            cwd=repo_dir,
+        )
+        if co.returncode != 0:
+            raise GitOpsError(f"git commit failed: {co.stderr.strip()}")
+
+        ps = _run(["git", "push", "-u", remote, branch], cwd=repo_dir)
+        if ps.returncode != 0:
+            raise GitOpsError(f"git push failed: {ps.stderr.strip()}")
+
+    except Exception:
+        if created_branch:
+            _run(["git", "switch", base], cwd=repo_dir)
+            _run(["git", "branch", "-D", branch], cwd=repo_dir)
+        raise

--- a/harness/lib/pr_opener.py
+++ b/harness/lib/pr_opener.py
@@ -1,13 +1,19 @@
 """PR opener boundary for the harness runner.
 
-Phase 1.2a ships a FakePROpener used in tests. Phase 1.2b adds a
-GhPROpener that calls `gh pr create` against a real remote.
+Phase 1.2a shipped FakePROpener for tests. 1.2b-ii adds GhPROpener
+which runs `gh pr create` against a real remote; the runner has
+already created, committed to, and pushed the branch via git_ops.
 """
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from typing import Optional, Protocol
+
+
+class PROpenerError(RuntimeError):
+    """Raised when opening a PR fails. Wraps captured stderr."""
 
 
 class PROpener(Protocol):
@@ -48,3 +54,49 @@ class FakePROpener:
                 json.dumps(record, indent=2)
             )
         return n
+
+
+class GhPROpener:
+    """Calls `gh pr create --json number -q .number` and parses the result.
+
+    Assumes the branch already exists locally and has been pushed (the
+    runner does this via git_ops.apply_diff_and_push before calling us).
+    """
+
+    def __init__(
+        self,
+        repo_dir: Path,
+        base_branch: str = "main",
+        gh_bin: str = "gh",
+    ) -> None:
+        self._repo_dir = repo_dir
+        self._base = base_branch
+        self._gh = gh_bin
+
+    def open(self, *, title: str, body: str, branch: str) -> int:
+        proc = subprocess.run(
+            [
+                self._gh, "pr", "create",
+                "--title", title,
+                "--body", body,
+                "--head", branch,
+                "--base", self._base,
+                "--json", "number",
+                "-q", ".number",
+            ],
+            cwd=str(self._repo_dir),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise PROpenerError(
+                f"gh pr create failed (exit {proc.returncode}): {proc.stderr.strip()}"
+            )
+        stripped = proc.stdout.strip()
+        try:
+            return int(stripped)
+        except ValueError:
+            raise PROpenerError(
+                f"gh pr create produced non-integer stdout: {stripped!r}"
+            )

--- a/harness/lib/runner.py
+++ b/harness/lib/runner.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, Optional
 from harness.lib import git_ops, ledger
 from harness.lib.git_ops import GitIdentity, GitOpsError
 from harness.lib.ledger import LedgerEntry
-from harness.lib.pr_opener import PROpener
+from harness.lib.pr_opener import PROpener, PROpenerError
 from harness.lib.skill_executor import SkillExecutor
 
 
@@ -134,7 +134,7 @@ def run_skill(
                 branch=branch,
             )
             status = "pr_opened"
-        except Exception as exc:  # narrowed to (GitOpsError, PROpenerError) in ii.3
+        except (GitOpsError, PROpenerError) as exc:
             tb = traceback.format_exc()
             status = "error"
             generator = None

--- a/harness/lib/runner.py
+++ b/harness/lib/runner.py
@@ -15,7 +15,8 @@ from pathlib import Path
 from time import monotonic
 from typing import Any, Callable, Optional
 
-from harness.lib import ledger
+from harness.lib import git_ops, ledger
+from harness.lib.git_ops import GitIdentity, GitOpsError
 from harness.lib.ledger import LedgerEntry
 from harness.lib.pr_opener import PROpener
 from harness.lib.skill_executor import SkillExecutor
@@ -54,6 +55,8 @@ def run_skill(
     pr_opener: PROpener,
     skill_name: Optional[str] = None,
     now: Optional[Callable[[], datetime]] = None,
+    base_branch: str = "main",
+    git_identity: Optional[GitIdentity] = None,
 ) -> LedgerEntry:
     """Run one skill against a repo. Returns the ledger entry appended.
 
@@ -62,6 +65,7 @@ def run_skill(
     """
     now = now or (lambda: datetime.now(timezone.utc))
     skill = skill_name or skill_dir.name
+    git_identity = git_identity or GitIdentity("tokenman-bot", "tokenman@local")
 
     # 2a. Allocate run_id.
     prev_n = ledger.last_run_id(ledger_path)
@@ -114,20 +118,29 @@ def run_skill(
             "diff_lines": diff_lines,
             "tokens": result.tokens,
         }
+        branch = f"tokenman/{skill}/{run_id}"
         try:
+            git_ops.apply_diff_and_push(
+                repo_dir=repo_dir,
+                diff_text=diff_text,
+                branch=branch,
+                base=base_branch,
+                message=f"[tokenman] {skill}: {result.summary}",
+                identity=git_identity,
+            )
             pr = pr_opener.open(
                 title=f"[tokenman] {skill}: {result.summary}",
                 body=result.summary,
-                branch=f"tokenman/{skill}/{run_id}",
+                branch=branch,
             )
             status = "pr_opened"
-        except Exception as exc:
+        except Exception as exc:  # narrowed to (GitOpsError, PROpenerError) in ii.3
             tb = traceback.format_exc()
             status = "error"
             generator = None
             pr = None
             (artifact_dir / "executor.stderr").write_text(
-                result.stderr + f"\n[runner] pr_opener failed: {exc}\n{tb}"
+                result.stderr + f"\n[runner] git/pr_opener failed: {exc}\n{tb}"
             )
 
     # 2h. Stop clock.

--- a/harness/lib/skill_executor.py
+++ b/harness/lib/skill_executor.py
@@ -1,15 +1,25 @@
 """Skill executor boundary for the harness runner.
 
 Phase 1.2a ships StubSkillExecutor for subprocess-driven tests.
-Phase 3+ adds ClaudeSkillExecutor that invokes `claude -p`.
+Phase 1.2b-ii adds ClaudeSkillExecutor that invokes `claude -p`.
 """
 from __future__ import annotations
 
+import json
 import os
+import shutil
 import subprocess
 from dataclasses import dataclass
+from importlib.resources import files
 from pathlib import Path
 from typing import Optional, Protocol
+
+
+_FRAMING_RESOURCE = files("harness.prompts") / "unattended_framing.v1.md"
+
+
+def _load_framing() -> str:
+    return _FRAMING_RESOURCE.read_text(encoding="utf-8")
 
 
 @dataclass
@@ -93,3 +103,140 @@ class StubSkillExecutor:
             prompt_version="stub-v1",
             tokens=0,
         )
+
+
+class ClaudeSkillExecutor:
+    """Runs `claude -p` against a scratch copy of the repo and computes
+    a proposed diff.
+
+    Phase 1.2b-ii. Satisfies the SkillExecutor Protocol.
+    """
+
+    def __init__(
+        self,
+        claude_bin: str = "claude",
+        timeout_s: int = 600,
+        prompt_version: str = "harness-v1",
+        extra_env: Optional[dict[str, str]] = None,
+        framing_text: Optional[str] = None,
+    ) -> None:
+        self._claude_bin = claude_bin
+        self._timeout_s = timeout_s
+        self._prompt_version = prompt_version
+        self._extra_env = dict(extra_env) if extra_env else {}
+        self._framing = framing_text if framing_text is not None else _load_framing()
+
+    def execute(
+        self,
+        skill_dir: Path,
+        repo_dir: Path,
+        scratch_dir: Path,
+    ) -> ExecutionResult:
+        working = scratch_dir / "working"
+        shutil.copytree(
+            repo_dir,
+            working,
+            ignore=shutil.ignore_patterns(".git", ".tokenman"),
+        )
+        skill_dst = working / ".claude" / "skills" / skill_dir.name
+        shutil.copytree(skill_dir, skill_dst, dirs_exist_ok=True)
+
+        user_prompt = (
+            f"Invoke the {skill_dir.name} skill. Edit files in place. "
+            "When complete, stop."
+        )
+        argv = [
+            self._claude_bin,
+            "-p",
+            "--output-format", "json",
+            "--append-system-prompt", self._framing,
+            user_prompt,
+        ]
+        env = {**os.environ, **self._extra_env}
+
+        timed_out = False
+        try:
+            proc = subprocess.run(
+                argv,
+                cwd=str(working),
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=self._timeout_s,
+                check=False,
+            )
+            stdout = proc.stdout
+            stderr = proc.stderr
+            exit_code = proc.returncode
+        except subprocess.TimeoutExpired as e:
+            stdout = e.stdout or ""
+            stderr = (e.stderr or "") + f"\n[executor] claude -p timed out after {self._timeout_s}s\n"
+            exit_code = -1
+            timed_out = True
+
+        summary, tokens = self._parse_json_output(stdout, exit_code)
+
+        diff_path: Optional[Path] = None
+        if not timed_out:
+            diff_proc = subprocess.run(
+                [
+                    "diff", "-ruN",
+                    "--exclude=.claude",
+                    "--exclude=.git",
+                    "--exclude=.tokenman",
+                    str(repo_dir), str(working),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            # `diff` returns 1 if differences exist; 0 if identical; >=2 is an error.
+            if diff_proc.returncode >= 2:
+                stderr += f"\n[executor] diff failed: {diff_proc.stderr.strip()}"
+            diff_output = diff_proc.stdout
+            if diff_output.strip():
+                diff_path = scratch_dir / "proposed.diff"
+                diff_path.write_text(diff_output)
+
+        md_path = scratch_dir / "proposed.md"
+        md_path.write_text(summary + "\n")
+
+        return ExecutionResult(
+            exit_code=exit_code,
+            stdout=stdout,
+            stderr=stderr,
+            proposed_diff_path=diff_path,
+            proposed_md_path=md_path,
+            summary=summary,
+            prompt_version=self._prompt_version,
+            tokens=tokens,
+        )
+
+    @staticmethod
+    def _parse_json_output(stdout: str, exit_code: int) -> tuple[str, int]:
+        """Return (summary, tokens) from claude -p --output-format json.
+
+        Defensive: falls back to the first non-empty stdout line for
+        summary if JSON parsing fails.
+        """
+        try:
+            doc = json.loads(stdout)
+        except json.JSONDecodeError:
+            first = next((ln for ln in stdout.splitlines() if ln.strip()),
+                         f"claude: exit {exit_code}")
+            return first, 0
+
+        summary = (
+            doc.get("result")
+            or doc.get("content")
+            or doc.get("message")
+            or f"claude: exit {exit_code}"
+        )
+        usage = doc.get("usage") or {}
+        tokens = (
+            int(usage.get("input_tokens", 0))
+            + int(usage.get("output_tokens", 0))
+            + int(usage.get("cache_creation_input_tokens", 0))
+            + int(usage.get("cache_read_input_tokens", 0))
+        )
+        return summary, tokens

--- a/harness/prompts/unattended_framing.v1.md
+++ b/harness/prompts/unattended_framing.v1.md
@@ -1,0 +1,9 @@
+You are running unattended as part of the tokenman harness.
+
+Rules:
+- No clarifying questions. Proceed with your best interpretation, or stop with no changes if genuinely blocked.
+- Stay within the scope declared by the skill you are invoking. Do not make changes outside that scope.
+- If the skill is inapplicable to this repository (e.g. the target file doesn't exist, or no change is warranted), stop without editing any files.
+- Do not modify `.tokenman/`, `.github/`, or `.claude/`. Read them only if the skill needs them for context.
+- Make your change atomically: prefer a single coherent edit over many small ones.
+- When complete, summarize what you changed (or why you did nothing) in your final message.

--- a/harness/run/__main__.py
+++ b/harness/run/__main__.py
@@ -1,0 +1,106 @@
+"""`python -m harness.run` — runs one skill against a consumer repo.
+
+Thin wrapper around harness.lib.runner.run_skill. Resolves skill_dir
+from recommended-skills.yaml. --dry-run swaps ClaudeSkillExecutor for
+the stub-readme fixture and GhPROpener for FakePROpener — useful for
+local iteration or smoke testing without spending tokens or opening
+real PRs.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from harness.lib import runner
+from harness.lib.pr_opener import FakePROpener, GhPROpener
+from harness.lib.skill_executor import ClaudeSkillExecutor, StubSkillExecutor
+
+
+def _repo_root() -> Path:
+    """Return the tokenman library repo root (where recommended-skills.yaml lives).
+
+    The CLI is invoked from the consumer's repo, but the catalog lives in
+    the tokenman library install. Walk up from this module's location to
+    find recommended-skills.yaml.
+    """
+    here = Path(__file__).resolve()
+    for candidate in here.parents:
+        if (candidate / "recommended-skills.yaml").is_file():
+            return candidate
+    raise SystemExit(
+        "recommended-skills.yaml not found; is tokenman installed correctly?"
+    )
+
+
+def _resolve_skill_dir(skill_name: str) -> Path:
+    root = _repo_root()
+    catalog_path = root / "recommended-skills.yaml"
+    catalog = yaml.safe_load(catalog_path.read_text()) or {}
+    entry = catalog.get(skill_name)
+    if entry is None:
+        raise SystemExit(f"skill {skill_name!r} not in recommended-skills.yaml")
+    source = entry.get("source")
+    if source is None:
+        raise SystemExit(f"skill {skill_name!r} has no 'source' field")
+    if source.startswith("./"):
+        return (root / source[2:]).resolve()
+    raise SystemExit(
+        f"only local (./) sources are supported in 1.2b; got {source!r}"
+    )
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m harness.run")
+    parser.add_argument("--skill", required=True)
+    parser.add_argument("--repo", default=".")
+    parser.add_argument("--ledger-path", default=None)
+    parser.add_argument("--runs-dir", default=None)
+    parser.add_argument("--claude-bin", default="claude")
+    parser.add_argument("--base-branch", default="main")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo).resolve()
+    ledger_path = (
+        Path(args.ledger_path) if args.ledger_path
+        else repo / ".tokenman" / "ledger.jsonl"
+    )
+    runs_dir = (
+        Path(args.runs_dir) if args.runs_dir
+        else repo / ".tokenman" / "runs"
+    )
+
+    skill_dir = _resolve_skill_dir(args.skill)
+
+    if args.dry_run:
+        root = _repo_root()
+        stub_skill = root / "tests" / "fixtures" / "skills" / "stub-readme"
+        executor = StubSkillExecutor(extra_env={"STUB_MODE": "propose_diff"})
+        pr_opener = FakePROpener(sink_dir=runs_dir.parent / "dry-run-prs")
+        effective_skill_dir = stub_skill
+    else:
+        executor = ClaudeSkillExecutor(claude_bin=args.claude_bin)
+        pr_opener = GhPROpener(repo_dir=repo, base_branch=args.base_branch)
+        effective_skill_dir = skill_dir
+
+    entry = runner.run_skill(
+        skill_dir=effective_skill_dir,
+        repo_dir=repo,
+        ledger_path=ledger_path,
+        runs_dir=runs_dir,
+        executor=executor,
+        pr_opener=pr_opener,
+        skill_name=args.skill,
+        base_branch=args.base_branch,
+    )
+    print(json.dumps(entry, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/harness/workflows/tokenman.yml.template
+++ b/harness/workflows/tokenman.yml.template
@@ -1,21 +1,66 @@
-# TEMPLATE — installed into consumer repos at /tokenman init as
-# .github/workflows/tokenman.yml. This file in the library repo never runs;
-# the installed copy on a consumer does.
+# TEMPLATE — installed into consumer repos at `/tokenman init` as
+# .github/workflows/tokenman.yml. This file in the library repo never
+# runs; the installed copy on a consumer does.
 #
-# Phase 0: stub. Phase 1 adds trigger-check + generator steps.
+# Phase 1.2b-ii: workflow_dispatch only. No PAUSE/cooldown/budget/lock
+# checks yet (those are Phase 2). No schedule yet.
+#
+# Requires: secrets.ANTHROPIC_API_KEY configured on the consumer repo.
 
 name: tokenman
 on:
   workflow_dispatch:
     inputs:
-      mode:
-        description: run mode (scheduled | onboarding | smoke)
-        default: scheduled
+      skill:
+        description: Skill to run (must exist in recommended-skills.yaml)
+        required: true
+        default: readme-maintainer
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   tokenman-run:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "tokenman.yml.template — Phase 0 stub. Not yet implemented."
-          exit 0
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install tokenman harness
+        run: pip install git+https://github.com/verkyyi/tokenman.git@main
+
+      - name: Install claude CLI
+        # TODO(1.2b-impl): resolve the actual install command at
+        # implementation time. Candidates include:
+        #   npm install -g @anthropic-ai/claude-code
+        #   curl -sSL https://claude.ai/install | sh
+        # Verify the chosen command during the manual smoke step.
+        run: |
+          echo "TODO: install claude here"
+          exit 1   # fail fast until the TODO is resolved
+
+      - name: Configure git identity for bot commits
+        run: |
+          git config --global user.email "tokenman-bot@users.noreply.github.com"
+          git config --global user.name  "tokenman-bot"
+
+      - name: Run tokenman
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN:          ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python -m harness.run \
+            --skill "${{ inputs.skill }}" \
+            --repo .
+
+      - name: Upload run artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tokenman-run-${{ github.run_id }}
+          path: .tokenman/runs/
+          if-no-files-found: warn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,13 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 norecursedirs = ["tests/fixtures"]
+markers = [
+    "live: tests that invoke a real external service (claude, gh). Requires TOKENMAN_LIVE=1.",
+]
 
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["harness*"]
+
+[tool.setuptools.package-data]
+"harness.prompts" = ["*.md"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires-python = ">=3.10"
 dev = [
   "pytest>=8",
   "jsonschema>=4.21",
+  "pyyaml>=6",
 ]
 
 [tool.pytest.ini_options]

--- a/recommended-skills.yaml
+++ b/recommended-skills.yaml
@@ -13,3 +13,14 @@
 #     evaluator_strictness: low | medium | high
 #
 # Empty at Phase 0. First entry added in Phase 1 (readme-maintainer).
+
+readme-maintainer:
+  source: ./skills/readme-maintainer    # TEMPORARY: in-tree during 1.2b (see skills/README.md)
+  version: 0.1.0
+  tier: starter
+  blast_radius: low
+  typical_tokens_per_run: 15000
+  description: Keeps README aligned with actual repo contents.
+  default_cadence: on-change
+  evaluator_strictness: medium
+  # TODO(1.2b-split): extract to standalone repo before Phase 3 dogfood opens.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,14 @@
+# `skills/` — bootstrap directory
+
+Temporary. This directory is a **bootstrap posture**: `readme-maintainer`
+lives in-tree during Phase 1.2b so the harness has a real skill to
+invoke without depending on an external repository that doesn't exist
+yet.
+
+Spec §5.1 says tokenman **ships zero skills**. This directory violates
+that principle on purpose and on a deadline: `readme-maintainer` must
+be split out to a standalone repository before Phase 3 opens dogfood
+runs against the library itself.
+
+Do not add more skills here. Real skills live in their own repos and
+are pinned in `recommended-skills.yaml` by URL.

--- a/skills/readme-maintainer/SKILL.md
+++ b/skills/readme-maintainer/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: readme-maintainer
+description: Keep the repo's README.md aligned with the actual contents of the repo.
+---
+
+# readme-maintainer
+
+**Version:** 0.1.0
+**Source:** tokenman library, `skills/readme-maintainer/` (temporary — see `skills/README.md`)
+
+## Scope
+
+Operates on `README.md` only. Does not read or modify other files.
+
+## Shape
+
+In-place edit. Prefer additive changes (new sections) over rewrites. If
+the README already describes the repo accurately, stop without edits.
+
+## Size limit
+
+Diff must be ≤ ~100 lines. If a bigger change is warranted, stop and
+surface the observation in your final message instead of making the
+edit.
+
+## Deterministic gate hints
+
+- Only `README.md` should appear in the diff.
+- No new files.
+- No deletions of entire top-level sections without an explicit reason.
+
+## Evaluator criteria (medium strictness)
+
+- Changes stay scoped to `README.md`.
+- Additions are factually grounded in other repo contents (do not
+  invent features).
+- Tone is consistent with the existing README.
+
+## Typical token budget
+
+~15 000 tokens per run (generator + evaluator combined).
+
+## Instructions
+
+When invoked:
+
+1. Read `README.md`.
+2. Read the repo structure (top-level files and directories) to
+   compare what's documented against what's present.
+3. If the README omits something significant (e.g. missing `Usage`,
+   `Install`, or `Development` section that the repo clearly supports),
+   propose an addition.
+4. If the README is already aligned with the repo, stop without edits
+   and say so in your final message.
+5. Stay within the size limit. If you think a bigger change is needed,
+   summarize the finding instead of making it.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import os
+import pytest
+
+
+def pytest_collection_modifyitems(config, items):
+    if os.environ.get("TOKENMAN_LIVE") == "1":
+        return
+    skip_live = pytest.mark.skip(reason="set TOKENMAN_LIVE=1 to run live tests")
+    for item in items:
+        if "live" in item.keywords:
+            item.add_marker(skip_live)

--- a/tests/fixtures/claude-captures/README.md
+++ b/tests/fixtures/claude-captures/README.md
@@ -1,0 +1,11 @@
+# `claude -p --output-format json` captures
+
+Each file is a recorded `stdout` from a real (or synthetic) invocation.
+Used by `tests/test_claude_skill_executor_replay.py` to validate the
+parser against real JSON shape without re-spending tokens.
+
+`readme-maintainer.json` is currently **synthetic** — refresh it with
+a real capture once `skills/readme-maintainer/` (ii.7) lands and
+`claude` is available locally. Capture snippet lives in
+`docs/superpowers/plans/2026-04-18-phase-1-2b-real-skill-integration.md`
+Task 25 Step 2.

--- a/tests/fixtures/claude-captures/readme-maintainer.json
+++ b/tests/fixtures/claude-captures/readme-maintainer.json
@@ -1,0 +1,13 @@
+{
+  "type": "result",
+  "subtype": "success",
+  "result": "Added a brief Usage section to README.md describing how to run the project.",
+  "usage": {
+    "input_tokens": 1245,
+    "output_tokens": 312,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0
+  },
+  "duration_ms": 8120,
+  "num_turns": 4
+}

--- a/tests/fixtures/skills/stub-readme/stub.sh
+++ b/tests/fixtures/skills/stub-readme/stub.sh
@@ -19,8 +19,10 @@ case "$MODE" in
     cat > "$SCRATCH/proposed.diff" <<'DIFF'
 --- a/README.md
 +++ b/README.md
-@@ -1,2 +1,3 @@
- # Tiny Python Repo
+@@ -1,3 +1,5 @@
+ # tiny-python-repo
+
+ Fixture for tokenman harness testing. Simulates a minimal Python consumer repo.
 +
 +Stub-readme added this line.
 DIFF

--- a/tests/test_claude_skill_executor_live.py
+++ b/tests/test_claude_skill_executor_live.py
@@ -1,0 +1,40 @@
+"""Opt-in live test that actually calls `claude -p`.
+
+Skipped unless TOKENMAN_LIVE=1 (configured in tests/conftest.py).
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from harness.lib.skill_executor import ClaudeSkillExecutor
+
+
+pytestmark = pytest.mark.live
+
+
+REPO_ROOT = Path(__file__).parent.parent
+SKILL_DIR = REPO_ROOT / "skills" / "readme-maintainer"  # added in ii.7
+FIXTURE = REPO_ROOT / "tests" / "fixtures" / "tiny-python-repo"
+
+
+def test_readme_maintainer_runs_without_crashing(tmp_path: Path) -> None:
+    if not SKILL_DIR.exists():
+        pytest.skip("skills/readme-maintainer/ not yet present (see ii.7)")
+
+    repo = tmp_path / "repo"
+    shutil.copytree(FIXTURE, repo)
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    executor = ClaudeSkillExecutor(timeout_s=600)
+    result = executor.execute(skill_dir=SKILL_DIR, repo_dir=repo, scratch_dir=scratch)
+
+    # Either claude produced a diff, or it chose not to — both are valid outcomes.
+    assert result.exit_code == 0, f"claude exited nonzero: {result.stderr}"
+    if result.proposed_diff_path is not None:
+        diff = result.proposed_diff_path.read_text()
+        assert "README.md" in diff, "skill should scope to README.md only"
+    assert result.tokens > 0, "live run should report a nonzero token count"

--- a/tests/test_claude_skill_executor_mock.py
+++ b/tests/test_claude_skill_executor_mock.py
@@ -1,0 +1,157 @@
+"""Unit tests for ClaudeSkillExecutor — plumbing only (subprocess mocked)."""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from harness.lib.skill_executor import ClaudeSkillExecutor
+
+
+def _make_skill_dir(tmp_path: Path) -> Path:
+    """A minimal skill directory with a SKILL.md placeholder."""
+    d = tmp_path / "skills" / "readme-maintainer"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(
+        "# readme-maintainer\n\nEdit README.md.\n"
+    )
+    return d
+
+
+def _make_repo_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "repo"
+    d.mkdir()
+    (d / "README.md").write_text("# Title\n\noriginal body\n")
+    return d
+
+
+def test_claude_invocation_argv_and_env(tmp_path: Path) -> None:
+    skill = _make_skill_dir(tmp_path)
+    repo = _make_repo_dir(tmp_path)
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    json_stdout = json.dumps({
+        "role": "assistant",
+        "result": "no-op, nothing to do",
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        },
+    })
+
+    with patch("harness.lib.skill_executor.subprocess.run") as m:
+        # First call is `claude -p ...`; second is `diff -ruN ...`.
+        m.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout=json_stdout, stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ]
+        executor = ClaudeSkillExecutor(claude_bin="claude", timeout_s=60)
+        result = executor.execute(skill_dir=skill, repo_dir=repo, scratch_dir=scratch)
+
+    # claude call: assert argv shape
+    claude_call = m.call_args_list[0]
+    argv = claude_call.args[0]
+    assert argv[0] == "claude"
+    assert "-p" in argv
+    assert "--output-format" in argv and "json" in argv
+    assert "--append-system-prompt" in argv
+    # cwd is the working copy inside scratch
+    assert claude_call.kwargs["cwd"].endswith(str(scratch / "working"))
+    # timeout passed
+    assert claude_call.kwargs["timeout"] == 60
+    # user prompt names the skill
+    assert any("readme-maintainer" in a for a in argv)
+
+    # Working copy exists and has the skill overlaid at .claude/skills/<name>
+    assert (scratch / "working" / "README.md").exists()
+    assert (scratch / "working" / ".claude" / "skills" / "readme-maintainer" / "SKILL.md").exists()
+
+    # Result fields
+    assert result.prompt_version == "harness-v1"
+    assert result.tokens == 150
+    assert result.exit_code == 0
+    assert result.proposed_diff_path is None  # diff stdout was empty
+    assert ("no-op" in result.summary.lower()) or ("nothing" in result.summary.lower())
+
+
+def test_claude_tokens_sum_with_cache_fields(tmp_path: Path) -> None:
+    skill = _make_skill_dir(tmp_path)
+    repo = _make_repo_dir(tmp_path)
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    json_stdout = json.dumps({
+        "role": "assistant",
+        "result": "stopped",
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "cache_creation_input_tokens": 100,
+            "cache_read_input_tokens": 200,
+        },
+    })
+
+    with patch("harness.lib.skill_executor.subprocess.run") as m:
+        m.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout=json_stdout, stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ]
+        executor = ClaudeSkillExecutor()
+        result = executor.execute(skill_dir=skill, repo_dir=repo, scratch_dir=scratch)
+
+    assert result.tokens == 10 + 20 + 100 + 200
+
+
+def test_claude_produces_diff_when_working_differs(tmp_path: Path) -> None:
+    skill = _make_skill_dir(tmp_path)
+    repo = _make_repo_dir(tmp_path)
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    json_stdout = json.dumps({
+        "role": "assistant",
+        "result": "added a section",
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    })
+    fake_diff = (
+        "--- a/README.md\n"
+        "+++ b/README.md\n"
+        "@@ -1 +1,2 @@\n"
+        " # Title\n"
+        "+## New\n"
+    )
+
+    with patch("harness.lib.skill_executor.subprocess.run") as m:
+        m.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout=json_stdout, stderr=""),
+            # `diff` returns 1 when differences exist; not an error for us.
+            subprocess.CompletedProcess(args=[], returncode=1, stdout=fake_diff, stderr=""),
+        ]
+        executor = ClaudeSkillExecutor()
+        result = executor.execute(skill_dir=skill, repo_dir=repo, scratch_dir=scratch)
+
+    assert result.proposed_diff_path is not None
+    assert (scratch / "proposed.diff").read_text() == fake_diff
+    assert (scratch / "proposed.md").exists()
+
+
+def test_claude_timeout_surfaces_as_error(tmp_path: Path) -> None:
+    skill = _make_skill_dir(tmp_path)
+    repo = _make_repo_dir(tmp_path)
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    with patch("harness.lib.skill_executor.subprocess.run") as m:
+        m.side_effect = subprocess.TimeoutExpired(cmd=["claude"], timeout=1)
+        executor = ClaudeSkillExecutor(timeout_s=1)
+        result = executor.execute(skill_dir=skill, repo_dir=repo, scratch_dir=scratch)
+
+    assert result.exit_code == -1
+    assert "timed out" in result.stderr
+    assert result.proposed_diff_path is None

--- a/tests/test_claude_skill_executor_replay.py
+++ b/tests/test_claude_skill_executor_replay.py
@@ -1,0 +1,36 @@
+"""Replays a recorded `claude -p --output-format json` stdout through
+ClaudeSkillExecutor._parse_json_output. Guards the parser against
+JSON-shape drift without spending real tokens.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from harness.lib.skill_executor import ClaudeSkillExecutor
+
+
+CAPTURE_PATH = (
+    Path(__file__).parent / "fixtures" / "claude-captures" / "readme-maintainer.json"
+)
+
+
+def test_parse_real_or_synthetic_capture() -> None:
+    raw = CAPTURE_PATH.read_text()
+    summary, tokens = ClaudeSkillExecutor._parse_json_output(raw, exit_code=0)
+
+    # The capture is either synthetic (see Task 25 Step 2) or real, but in
+    # either case the following invariants must hold.
+    assert isinstance(summary, str) and summary.strip(), "summary must be non-empty string"
+    assert tokens > 0, "tokens must be positive for a real/synthetic capture"
+
+    # The usage block should have been consumable.
+    doc = json.loads(raw)
+    usage = doc.get("usage", {})
+    expected = (
+        int(usage.get("input_tokens", 0))
+        + int(usage.get("output_tokens", 0))
+        + int(usage.get("cache_creation_input_tokens", 0))
+        + int(usage.get("cache_read_input_tokens", 0))
+    )
+    assert tokens == expected

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,76 @@
+"""End-to-end test for the harness.run CLI (subprocess invocation)."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).parent.parent
+TINY_PYTHON_REPO = REPO_ROOT / "tests" / "fixtures" / "tiny-python-repo"
+
+
+def _seed_git_repo(repo: Path, remote: Path) -> None:
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "init", "-b", "main"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "seed@local"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name",  "seed"], check=True)
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "seed"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "remote", "add", "origin", str(remote)], check=True)
+    subprocess.run(["git", "-C", str(repo), "push", "-u", "origin", "main"], check=True, capture_output=True)
+
+
+def test_cli_dry_run_produces_ledger_entry(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    shutil.copytree(TINY_PYTHON_REPO, repo)
+    remote = tmp_path / "remote.git"
+    _seed_git_repo(repo, remote)
+
+    env = {**os.environ}
+    proc = subprocess.run(
+        [
+            sys.executable, "-m", "harness.run",
+            "--skill", "readme-maintainer",
+            "--repo", str(repo),
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(REPO_ROOT),
+    )
+
+    assert proc.returncode == 0, f"stderr: {proc.stderr}"
+
+    ledger_path = repo / ".tokenman" / "ledger.jsonl"
+    assert ledger_path.is_file(), "ledger file must be created"
+    lines = [ln for ln in ledger_path.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["run_id"] == "r-0001"
+    assert entry["skill"] == "readme-maintainer"
+    assert entry["status"] in {"pr_opened", "no_change"}
+
+    # stdout ends with the compact JSON entry
+    last_stdout_line = [ln for ln in proc.stdout.splitlines() if ln.strip()][-1]
+    assert json.loads(last_stdout_line) == entry
+
+
+def test_cli_unknown_skill_exits_nonzero(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        [
+            sys.executable, "-m", "harness.run",
+            "--skill", "does-not-exist",
+            "--repo", str(tmp_path),
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert proc.returncode != 0
+    assert "does-not-exist" in proc.stderr

--- a/tests/test_gh_pr_opener.py
+++ b/tests/test_gh_pr_opener.py
@@ -1,0 +1,69 @@
+"""Unit tests for harness.lib.pr_opener.GhPROpener."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from harness.lib.pr_opener import GhPROpener, PROpenerError
+
+
+def test_gh_pr_opener_builds_expected_argv(tmp_path: Path) -> None:
+    opener = GhPROpener(repo_dir=tmp_path, base_branch="main", gh_bin="gh")
+
+    with patch("harness.lib.pr_opener.subprocess.run") as m:
+        m.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="4242\n", stderr=""
+        )
+        pr = opener.open(
+            title="[tokenman] readme-maintainer: add section",
+            body="Proposed change.",
+            branch="tokenman/readme-maintainer/r-0001",
+        )
+
+    assert pr == 4242
+    args, kwargs = m.call_args
+    cmd = args[0]
+    assert cmd[0] == "gh"
+    assert cmd[1:3] == ["pr", "create"]
+    assert "--title" in cmd and "[tokenman] readme-maintainer: add section" in cmd
+    assert "--body" in cmd and "Proposed change." in cmd
+    assert "--head" in cmd and "tokenman/readme-maintainer/r-0001" in cmd
+    assert "--base" in cmd and "main" in cmd
+    assert "--json" in cmd and "number" in cmd
+    assert "-q" in cmd and ".number" in cmd
+    assert kwargs["cwd"] == str(tmp_path)
+
+
+def test_gh_pr_opener_raises_on_nonzero_exit(tmp_path: Path) -> None:
+    opener = GhPROpener(repo_dir=tmp_path)
+
+    with patch("harness.lib.pr_opener.subprocess.run") as m:
+        m.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="",
+            stderr="HTTP 422: Validation Failed",
+        )
+        with pytest.raises(PROpenerError) as exc:
+            opener.open(title="t", body="b", branch="br")
+        assert "422" in str(exc.value)
+
+
+def test_gh_pr_opener_parses_number_with_trailing_whitespace(tmp_path: Path) -> None:
+    opener = GhPROpener(repo_dir=tmp_path)
+    with patch("harness.lib.pr_opener.subprocess.run") as m:
+        m.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="  17\n\n", stderr=""
+        )
+        assert opener.open(title="t", body="b", branch="br") == 17
+
+
+def test_gh_pr_opener_raises_on_non_integer_stdout(tmp_path: Path) -> None:
+    opener = GhPROpener(repo_dir=tmp_path)
+    with patch("harness.lib.pr_opener.subprocess.run") as m:
+        m.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="not-a-number\n", stderr=""
+        )
+        with pytest.raises(PROpenerError):
+            opener.open(title="t", body="b", branch="br")

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1,0 +1,109 @@
+"""Unit tests for harness.lib.git_ops."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from harness.lib.git_ops import (
+    GitIdentity,
+    GitOpsError,
+    apply_diff_and_push,
+)
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def _make_repo_with_bare_remote(tmp_path: Path) -> tuple[Path, Path]:
+    """Initialise a working repo with a bare remote at tmp_path/remote.
+    Returns (repo_dir, remote_dir). repo_dir has one commit on main and
+    tracks origin=main.
+    """
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    (repo / "README.md").write_text("# Hello\n")
+    _git(repo, "config", "user.email", "seed@local")
+    _git(repo, "config", "user.name",  "seed")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "seed")
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-u", "origin", "main")
+    return repo, remote
+
+
+IDENTITY = GitIdentity(name="tokenman-bot", email="tokenman@local")
+
+
+def test_apply_diff_and_push_creates_branch_commit_push(tmp_path: Path) -> None:
+    repo, remote = _make_repo_with_bare_remote(tmp_path)
+    diff_text = (
+        "--- a/README.md\n"
+        "+++ b/README.md\n"
+        "@@ -1 +1,2 @@\n"
+        " # Hello\n"
+        "+## New section\n"
+    )
+    apply_diff_and_push(
+        repo_dir=repo,
+        diff_text=diff_text,
+        branch="tokenman/readme-maintainer/r-0001",
+        base="main",
+        message="[tokenman] readme-maintainer: add section",
+        identity=IDENTITY,
+    )
+
+    # local branch exists
+    branches = _git(repo, "branch", "--list")
+    assert "tokenman/readme-maintainer/r-0001" in branches
+
+    # commit author identity is ours
+    log = _git(repo, "log", "-1", "--format=%an <%ae> %s", "tokenman/readme-maintainer/r-0001")
+    assert "tokenman-bot <tokenman@local>" in log
+    assert "add section" in log
+
+    # switching to the branch shows the applied change
+    _git(repo, "switch", "tokenman/readme-maintainer/r-0001")
+    assert "## New section" in (repo / "README.md").read_text()
+
+    # remote has the pushed branch
+    remote_refs = subprocess.run(
+        ["git", "ls-remote", str(remote)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "refs/heads/tokenman/readme-maintainer/r-0001" in remote_refs
+
+
+def test_apply_diff_and_push_raises_on_bad_diff(tmp_path: Path) -> None:
+    repo, _ = _make_repo_with_bare_remote(tmp_path)
+    bogus_diff = "not a valid unified diff at all\n"
+    with pytest.raises(GitOpsError):
+        apply_diff_and_push(
+            repo_dir=repo,
+            diff_text=bogus_diff,
+            branch="tokenman/does-not-matter/r-0001",
+            base="main",
+            message="won't apply",
+            identity=IDENTITY,
+        )
+
+    # no branch left behind with extra commits
+    branches = _git(repo, "branch", "--list")
+    if "tokenman/does-not-matter/r-0001" in branches:
+        head = _git(repo, "rev-parse", "tokenman/does-not-matter/r-0001").strip()
+        base = _git(repo, "rev-parse", "main").strip()
+        assert head == base

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -78,12 +79,37 @@ def _prepare_repo_copy(tmp_path: Path) -> tuple[Path, Path, Path]:
     return repo_dir, ledger_path, runs_dir
 
 
+def _prepare_repo_copy_with_remote(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    """Return (repo_dir, ledger_path, runs_dir, remote_dir).
+
+    repo_dir is a fresh copy of the fixture + `git init` + initial commit
+    + origin pointing at remote_dir (a bare repo).
+    """
+    repo_dir = tmp_path / "repo"
+    shutil.copytree(TINY_PYTHON_REPO, repo_dir)
+    tokenman_dir = repo_dir / ".tokenman"
+    tokenman_dir.mkdir(exist_ok=True)
+    ledger_path = tokenman_dir / "ledger.jsonl"
+    runs_dir = tokenman_dir / "runs"
+
+    remote_dir = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(remote_dir)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo_dir), "init", "-b", "main"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo_dir), "config", "user.email", "seed@local"], check=True)
+    subprocess.run(["git", "-C", str(repo_dir), "config", "user.name",  "seed"], check=True)
+    subprocess.run(["git", "-C", str(repo_dir), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(repo_dir), "commit", "-m", "seed"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo_dir), "remote", "add", "origin", str(remote_dir)], check=True)
+    subprocess.run(["git", "-C", str(repo_dir), "push", "-u", "origin", "main"], check=True, capture_output=True)
+    return repo_dir, ledger_path, runs_dir, remote_dir
+
+
 def _fixed_now() -> datetime:
     return datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
 
 
 def test_run_skill_propose_diff_opens_pr(tmp_path: Path) -> None:
-    repo_dir, ledger_path, runs_dir = _prepare_repo_copy(tmp_path)
+    repo_dir, ledger_path, runs_dir, remote_dir = _prepare_repo_copy_with_remote(tmp_path)
     executor = StubSkillExecutor(extra_env={"STUB_MODE": "propose_diff"})
     pr_opener = FakePROpener(sink_dir=tmp_path / "prs", start=1000)
 
@@ -129,6 +155,13 @@ def test_run_skill_propose_diff_opens_pr(tmp_path: Path) -> None:
     assert call["branch"] == "tokenman/stub-readme/r-0001"
     diff_on_disk = (runs_dir / "r-0001" / "proposed.diff").read_text()
     assert "Stub-readme added this line" in diff_on_disk
+
+    # Branch exists on origin (bare remote)
+    ls = subprocess.run(
+        ["git", "ls-remote", str(remote_dir), "refs/heads/tokenman/stub-readme/r-0001"],
+        capture_output=True, text=True, check=True,
+    )
+    assert "tokenman/stub-readme/r-0001" in ls.stdout
 
 
 def test_run_skill_no_change_skips_pr_opener(tmp_path: Path) -> None:
@@ -313,7 +346,7 @@ def test_run_skill_records_error_when_pr_opener_raises(tmp_path: Path) -> None:
     error outcome rather than crashing: status=error, generator=None,
     pr=None, stderr captures the traceback, ledger has exactly one entry.
     """
-    repo_dir, ledger_path, runs_dir = _prepare_repo_copy(tmp_path)
+    repo_dir, ledger_path, runs_dir, _remote_dir = _prepare_repo_copy_with_remote(tmp_path)
 
     class BrokenPROpener:
         def open(self, *, title, body, branch):
@@ -348,5 +381,5 @@ def test_run_skill_records_error_when_pr_opener_raises(tmp_path: Path) -> None:
     art = runs_dir / "r-0001"
     assert (art / "proposed.diff").is_file()
     stderr_content = (art / "executor.stderr").read_text()
-    assert "pr_opener failed: boom" in stderr_content
+    assert "git/pr_opener failed: boom" in stderr_content
     assert "RuntimeError" in stderr_content

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 
 from harness.lib import ledger, runner
-from harness.lib.pr_opener import FakePROpener
+from harness.lib.pr_opener import FakePROpener, PROpenerError
 from harness.lib.skill_executor import StubSkillExecutor
 
 
@@ -350,7 +350,7 @@ def test_run_skill_records_error_when_pr_opener_raises(tmp_path: Path) -> None:
 
     class BrokenPROpener:
         def open(self, *, title, body, branch):
-            raise RuntimeError("boom")
+            raise PROpenerError("boom")
 
     executor = StubSkillExecutor(extra_env={"STUB_MODE": "propose_diff"})
     pr_opener = BrokenPROpener()
@@ -382,4 +382,4 @@ def test_run_skill_records_error_when_pr_opener_raises(tmp_path: Path) -> None:
     assert (art / "proposed.diff").is_file()
     stderr_content = (art / "executor.stderr").read_text()
     assert "git/pr_opener failed: boom" in stderr_content
-    assert "RuntimeError" in stderr_content
+    assert "PROpenerError" in stderr_content


### PR DESCRIPTION
## Summary

Swaps 1.2a's stub boundary classes for real ones, lands the first cataloged skill, adds a runner CLI, and produces a consumer-deployable workflow template. Parent spec: \`docs/superpowers/specs/2026-04-18-phase-1-2b-real-skill-integration-design.md\`.

- \`harness/lib/git_ops.py\` — \`apply_diff_and_push\` (branch/apply/commit/push with rollback) \`3e8fb7a\`
- Runner wires git_ops in before PR open; tests seed a real git repo + bare remote \`c7b8a34\`
- \`GhPROpener\` — thin \`gh pr create --json number -q .number\` wrapper; runner's except clause narrows to \`(GitOpsError, PROpenerError)\` \`f9b4dfc\`
- \`ClaudeSkillExecutor\` — copies repo → scratch, overlays skill into \`.claude/skills/<name>/\`, invokes \`claude -p --output-format json\` with versioned framing, diffs after; \`live\` pytest marker gated on \`TOKENMAN_LIVE=1\` \`16bcd35\`
- Recorded claude-output fixture + replay test (synthetic for now — flagged to refresh with a real capture) \`ee0f47f\`
- \`python -m harness.run\` CLI with \`--dry-run\` escape hatch; \`recommended-skills.yaml\` gains its first entry \`6ddbc66\`
- First skill \`readme-maintainer\` in-tree at \`skills/readme-maintainer/\` with a bootstrap README explaining the temporary posture \`b4cee4d\`
- Functional \`tokenman.yml.template\` (workflow_dispatch, uploads artifacts, one TODO for the \`claude\` install step) \`415d579\`
- \`.tokenman/CLAUDE.md\` adds \`skills/\` to the forbidden list; CONTRIBUTING.md documents the bootstrap posture and refreshes the runtime-modules section \`b0877b8\`

## Test plan

- [x] \`pytest -q\` green: 64 passed, 1 skipped (the live test)
- [x] \`TOKENMAN_LIVE=1 pytest -m live\` passes locally (25s against real \`claude\` on the tiny-python-repo fixture)
- [x] \`python -c \"from harness.lib import ledger, runner, skill_executor, pr_opener, git_ops; from harness.run import __main__\"\` — clean imports after \`pip install -e '.[dev]'\`
- [ ] Manual \`workflow_dispatch\` smoke against a throwaway repo — **deferred**; requires resolving the \`TODO(1.2b-impl)\` install step in the workflow template. Open question: pick an install command now or leave as-is until a consumer onboards.
- [ ] Reviewer: confirm the \`skills/\` bootstrap is tagged as temporary in all three places (\`skills/README.md\`, \`recommended-skills.yaml\` TODO comment, \`.tokenman/CLAUDE.md\` + \`CONTRIBUTING.md\`)

## Out of scope

PAUSE check, cooldown, budget cap, open-PR lock (Phase 2). Evaluator stage (Phase 3). Retention/GC (Phase 2). Real library-repo dogfood (Phase 3 gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)